### PR TITLE
UPDATE Import certs without ca flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ See additional repos for more info:
 
 ### Get prerequisites
 
-Ensure that you have a local version of the CredHub CLI checked out in your $GOPATH
+Ensure that you have a local version of the CredHub CLI and ginkgo checked out in your $GOPATH
 
+Install the CredHub CLI
 ```sh
 go get code.cloudfoundry.org/credhub-cli
 ```
+
+To install ginkgo see [ginkgo installation](https://github.com/onsi/ginkgo#global-installation)
+
 
 ### Run Tests locally
 

--- a/integration_test/import_export_test.go
+++ b/integration_test/import_export_test.go
@@ -1,13 +1,14 @@
 package integration_test
 
 import (
+	"io/ioutil"
+	"os"
+
 	. "github.com/cloudfoundry-incubator/credhub-acceptance-tests/test_helpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
-	"os"
 )
 
 var _ = Describe("Import/Export test", func() {
@@ -103,15 +104,15 @@ var _ = Describe("Import/Export test", func() {
 	})
 })
 
-	func getTrimmedCertificateForComparison(name string) map[string]interface{}{
-		session = RunCommand("get", "--name", name)
-		Expect(session).To(Exit(0))
+func getTrimmedCertificateForComparison(name string) map[string]interface{} {
+	session = RunCommand("get", "--name", name)
+	Expect(session).To(Exit(0))
 
-		certificate := make(map[string]interface{})
-		err := yaml.Unmarshal(session.Out.Contents(), certificate)
-		Expect(err).NotTo(HaveOccurred())
-		delete(certificate, "version_created_at")
-		delete(certificate, "id")
+	certificate := make(map[string]interface{})
+	err := yaml.Unmarshal(session.Out.Contents(), certificate)
+	Expect(err).NotTo(HaveOccurred())
+	delete(certificate, "version_created_at")
+	delete(certificate, "id")
 
-		return certificate
-	}
+	return certificate
+}


### PR DESCRIPTION
Hi all,

I just added the test for the latest PR / Change at CredHub plus a small README Update

With the new test, it's possible to validate that the import of a self signed certificate (without a "valid" ca was working)

CredHub PR: [#150](https://github.com/cloudfoundry-incubator/credhub/pull/150)
CredHub Issue: [#134](https://github.com/cloudfoundry-incubator/credhub/issues/134)

Other PR (that will be rejected but good to know) [#139](https://github.com/cloudfoundry-incubator/credhub/pull/139)

Kind regards
Tobi 